### PR TITLE
Improve check_tool to show error when tool is not found by `which`

### DIFF
--- a/ssh-uuid.sh
+++ b/ssh-uuid.sh
@@ -389,10 +389,8 @@ function get_rand_port_num {
 }
 
 function check_tool {
-	local tool
-	tool=$(which "$1")
-	if [[ ! -x "${tool}" ]]; then
-		quit "Unable to execute '${tool}'. Is it installed?"
+	if [ ! $(which "$1") ]; then
+		quit "'$1' not found in PATH. Is it installed?"
 	fi
 }
 


### PR DESCRIPTION
Thanks @pdcastro for this repo, I find it very useful!

This is a small fix to report missing tools instead of ending with an error and empty message.