### PR TITLE
Ensure `do_proxy` background socat is waited on to avoid zombie

### DIFF
--- a/ssh-uuid.sh
+++ b/ssh-uuid.sh
@@ -366,12 +366,14 @@ function do_proxy {
 	socat "TCP-LISTEN:${SOCAT_PORT},bind=127.0.0.1" "OPENSSL:tunnel.balena-cloud.com:443,snihost=tunnel.balena-cloud.com" &
 	{ set +x; } 2>/dev/null
 	sleep 1 # poor man's wait for the background socat process to be ready
-	[ -n "${DEBUG}" ] && set -x
 	set +e
+	[ -n "${DEBUG}" ] && set -x
 	socat - "PROXY:127.0.0.1:${TARGET_HOST}:${TARGET_PORT},proxyport=${SOCAT_PORT},proxy-authorization-file=${PROXY_AUTH_FILE}"
 	{ local status="$?"; [ -n "${DEBUG}" ] && set +x; } 2>/dev/null
 	set -e
-	kill $(jobs -p) && wait # shutdown background tunnel
+	local pid
+	pid="$(jobs -p)"
+	[ -n "${pid}" ] && kill "${pid}" && wait # shutdown background tunnel
 	return "${status}"
 }
 

--- a/ssh-uuid.sh
+++ b/ssh-uuid.sh
@@ -367,8 +367,11 @@ function do_proxy {
 	{ set +x; } 2>/dev/null
 	sleep 1 # poor man's wait for the background socat process to be ready
 	[ -n "${DEBUG}" ] && set -x
+	set +e
 	socat - "PROXY:127.0.0.1:${TARGET_HOST}:${TARGET_PORT},proxyport=${SOCAT_PORT},proxy-authorization-file=${PROXY_AUTH_FILE}"
 	{ local status="$?"; [ -n "${DEBUG}" ] && set +x; } 2>/dev/null
+	set -e
+	kill $(jobs -p) && wait # shutdown background tunnel
 	return "${status}"
 }
 


### PR DESCRIPTION
If our ProxyCommand fails due to an error, we currently immediately terminate due to `set -e` and never wait on the backgrounded socat tunnel, creating a zombie - it can be seen:
```bash
~ ssh-uuid xxxxxxx.balena & 
[1] 69092

~ ps aux -H
...
root      446474  0.0  0.0   2588  1920 pts/0    S+   00:29   0:00       bash /usr/bin/ssh-uuid xxxxxxx.balena
root      446476  0.0  0.1   6564  4352 pts/0    S+   00:29   0:00         ssh -o ProxyCommand='/usr/bin/ssh-uuid' do_proxy %h %p -p 22222 -l username xxxxxxx.balena
root      446477  0.0  0.0   2588  1792 pts/0    S+   00:29   0:00           bash /usr/bin/ssh-uuid do_proxy 733f71add5b7f8b2490f5832e5fa5adf.balena 22222
root      446480  0.0  0.0   6972  2176 pts/0    S+   00:29   0:00             socat TCP-LISTEN:55306,bind=127.0.0.1 OPENSSL:tunnel.balena-cloud.com:443,snihost=tunnel.balena-cloud.com
root      446481  0.0  0.0   1624   768 pts/0    S+   00:29   0:00             sleep 1
...

2025/04/08 18:05:54 socat[69035] W OpenSSL: Warning: this implementation does not check CRLs
2025/04/08 18:05:54 socat[69037] E CONNECT xxxxxxx.balena:22222: Service Unavailable
2025/04/08 18:05:54 socat[69035] E read(6, 0x150014000, 8192): Connection reset by peer
Connection closed by UNKNOWN port 65535
[1]  + 69092 exit 255

~ ps aux | grep -e 446474 -e 446476 -e 446477 -e 446480 -e 446481
root      446480  0.0  0.0      0     0 pts/0    Z    00:29   0:00 [socat] <defunct>
````

If `ssh-uuid` is used frequently, these will ultimately create a bunch of zombied processes. Instead, we can temporarily `set +e` again around the foreground socat call and ensure teardown takes place before returning the error code.